### PR TITLE
Fix card scanner import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ The main menu lets you choose between scanning cards, viewing your collection, o
 ## Scanning cards from images
 
 Scans of cards placed in `assets/scans` can be processed in batch using
-`scanner/card_scanner.py`. The script performs OCR on each image and stores the
-results in `data/cards_scanned.csv`:
+`scanner/card_scanner.py`. Execute the script from the repository root so that
+the ``scanner`` package is discoverable. The script performs OCR on each image
+and stores the results in `data/cards_scanned.csv`:
 
 ```bash
 python scanner/card_scanner.py
+```
+
+Alternatively you can launch it as a module:
+
+```bash
+python -m scanner.card_scanner
 ```
 
 Ensure the `tesseract` binary is installed and available in your `PATH` for OCR

--- a/scanner/card_scanner.py
+++ b/scanner/card_scanner.py
@@ -3,8 +3,10 @@
 from pathlib import Path
 import re
 
-from .ocr_engine import extract_text
-from .data_exporter import export_to_csv
+# Use absolute imports so the script can be executed directly
+# or via ``python -m`` without package issues.
+from scanner.ocr_engine import extract_text
+from scanner.data_exporter import export_to_csv
 
 RARITY_KEYWORDS = [
     "Common",


### PR DESCRIPTION
## Summary
- adjust imports in `card_scanner.py` so the script can be executed directly
- clarify README instructions for running `card_scanner`

## Testing
- `python -m scanner.card_scanner` *(fails: ModuleNotFoundError: No module named 'pytesseract')*
- `pip install -r requirements.txt` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68638d930a48832fbdf70131797b8bee