### PR TITLE
Fix running card_scanner from scanner directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,12 @@ Alternatively you can launch it as a module:
 python -m scanner.card_scanner
 ```
 
+You can also execute the script from within the ``scanner`` directory:
+
+```bash
+cd scanner
+python card_scanner.py
+```
+
 Ensure the `tesseract` binary is installed and available in your `PATH` for OCR
 to work correctly.

--- a/scanner/card_scanner.py
+++ b/scanner/card_scanner.py
@@ -2,6 +2,11 @@
 
 from pathlib import Path
 import re
+import sys
+
+# Allow running the script directly from the ``scanner`` directory
+if __name__ == "__main__" and __package__ is None:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 # Use absolute imports so the script can be executed directly
 # or via ``python -m`` without package issues.


### PR DESCRIPTION
## Summary
- enable `card_scanner.py` to adjust `sys.path` when run from its folder
- document running `card_scanner.py` from the `scanner` directory

## Testing
- `python -m compileall .`
- `python scanner/card_scanner.py` *(fails: pytesseract not installed)*
- `cd scanner && python card_scanner.py` *(fails: pytesseract not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68638e622990832fa5e9de6fa3f49320