### PR TITLE
Fix extract_text compatibility

### DIFF
--- a/scanner/card_scanner.py
+++ b/scanner/card_scanner.py
@@ -1,8 +1,10 @@
 """Batch scanner for extracting data from card images."""
 
 from pathlib import Path
+import os
 import re
 import sys
+import tempfile
 
 # Allow running the script directly from the ``scanner`` directory
 if __name__ == "__main__" and __package__ is None:
@@ -22,6 +24,28 @@ RARITY_KEYWORDS = [
     "Secret Rare",
     "Promo",
 ]
+
+
+def _extract_text_compat(path: str, bbox: tuple | None) -> str:
+    """Call :func:`extract_text` with optional bounding box support.
+
+    Older versions of :func:`extract_text` did not accept a ``bbox`` keyword
+    argument.  This helper catches ``TypeError`` and falls back to cropping the
+    image manually before calling ``extract_text`` again without ``bbox``.
+    """
+    try:
+        return extract_text(path, bbox=bbox)
+    except TypeError:
+        image = Image.open(path)
+        if bbox:
+            image = image.crop(bbox)
+        with tempfile.NamedTemporaryFile(delete=False, suffix=Path(path).suffix) as tmp:
+            tmp_path = tmp.name
+        image.save(tmp_path)
+        try:
+            return extract_text(tmp_path)
+        finally:
+            os.remove(tmp_path)
 
 
 def parse_card_text(text: str, name_override: str | None = None) -> dict:
@@ -53,12 +77,12 @@ def scan_image(path: Path) -> dict:
 
     # Name is typically in the upper part of the card
     name_bbox = (0, 0, width // 2, int(height * 0.15))
-    name_text = extract_text(str(path), bbox=name_bbox)
+    name_text = _extract_text_compat(str(path), name_bbox)
     name_line = name_text.splitlines()[0].strip() if name_text.splitlines() else "Unknown"
 
     # Set info and number usually reside near the bottom right
     info_bbox = (width // 2, int(height * 0.8), width, height)
-    info_text = extract_text(str(path), bbox=info_bbox)
+    info_text = _extract_text_compat(str(path), info_bbox)
 
     return parse_card_text(info_text, name_override=name_line)
 

--- a/tests/test_card_scanner.py
+++ b/tests/test_card_scanner.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from PIL import Image
+import pytest
+
+import scanner.card_scanner as card_scanner
+
+
+def create_dummy_image(path: Path) -> None:
+    Image.new("RGB", (100, 100), color="white").save(path)
+
+
+def test_scan_image_fallback(tmp_path, monkeypatch):
+    img_path = tmp_path / "test.jpg"
+    create_dummy_image(img_path)
+
+    calls = []
+
+    def fake_extract_text(path, bbox=None):
+        calls.append((path, bbox))
+        if bbox is not None:
+            raise TypeError("unexpected keyword")
+        return "Name\nSet: Base\n1/102"
+
+    monkeypatch.setattr(card_scanner, "extract_text", fake_extract_text)
+
+    data = card_scanner.scan_image(img_path)
+
+    assert data["Name"] == "Name"
+    assert data["Set"] == "Base"
+    assert data["Number"] == "1/102"
+    # First call uses bbox and fails, second call should not pass bbox
+    assert len(calls) == 2
+    assert calls[1][1] is None
+    # Should use a temporary path for the second call
+    assert Path(calls[1][0]) != img_path
+    assert not Path(calls[1][0]).exists()


### PR DESCRIPTION
## Summary
- ensure scanner works with older extract_text function that lacks `bbox`
- add regression test for fallback behavior

## Testing
- `pytest -q` *(fails: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68639c164760832fbd061380c3bb47f6