### PR TITLE
Improve card scanner workflow

### DIFF
--- a/scanner/card_scanner.py
+++ b/scanner/card_scanner.py
@@ -1,6 +1,7 @@
 """Batch scanner for extracting data from card images."""
 
 from pathlib import Path
+from collections import defaultdict
 import os
 import re
 import sys
@@ -48,23 +49,27 @@ def _extract_text_compat(path: str, bbox: tuple | None) -> str:
             os.remove(tmp_path)
 
 
-def parse_card_text(text: str, name_override: str | None = None) -> dict:
-    """Parse OCR text and return card attributes."""
-    lines = [line.strip() for line in text.splitlines() if line.strip()]
-    name = lines[0] if lines else "Unknown"
-    if name_override:
-        name = name_override
+def parse_card_text(name_text: str, number_text: str) -> dict:
+    """Parse card name and additional info from OCR text fragments."""
+    # Name comes from the upper crop of the card image
+    name_lines = [line.strip() for line in name_text.splitlines() if line.strip()]
+    name = name_lines[0] if name_lines else "Unknown"
 
-    number_match = re.search(r"(\d+/\d+)", text)
+    # Number, set and rarity usually appear near the bottom of the card
+    combined = "\n".join(
+        line.strip() for line in number_text.splitlines() if line.strip()
+    )
+
+    number_match = re.search(r"(\d+/\d+)", combined)
     number = number_match.group(1) if number_match else ""
 
     rarity = ""
     for r in RARITY_KEYWORDS:
-        if re.search(r, text, re.IGNORECASE):
+        if re.search(r, combined, re.IGNORECASE):
             rarity = r
             break
 
-    set_match = re.search(r"Set[:\s]*(.+)", text, re.IGNORECASE)
+    set_match = re.search(r"Set[:\s]*(.+)", combined, re.IGNORECASE)
     set_name = set_match.group(1).strip() if set_match else ""
 
     return {"Name": name, "Set": set_name, "Rarity": rarity, "Number": number}
@@ -75,25 +80,33 @@ def scan_image(path: Path) -> dict:
     image = Image.open(path)
     width, height = image.size
 
-    # Name is typically in the upper part of the card
-    name_bbox = (0, 0, width // 2, int(height * 0.15))
+    # Name: top 10% of the card, cropped with horizontal margins
+    name_bbox = (
+        int(width * 0.1),
+        0,
+        int(width * 0.9),
+        int(height * 0.1),
+    )
     name_text = _extract_text_compat(str(path), name_bbox)
-    name_line = name_text.splitlines()[0].strip() if name_text.splitlines() else "Unknown"
 
-    # Set info and number usually reside near the bottom right
-    info_bbox = (width // 2, int(height * 0.8), width, height)
-    info_text = _extract_text_compat(str(path), info_bbox)
+    # Number and other info: bottom 15% of the card, near the right edge
+    number_bbox = (
+        int(width * 0.6),
+        int(height * 0.85),
+        int(width * 0.95),
+        height,
+    )
+    number_text = _extract_text_compat(str(path), number_bbox)
 
-    return parse_card_text(info_text, name_override=name_line)
+    return parse_card_text(name_text, number_text)
 
 
 def scan_directory(dir_path: Path) -> list:
     """Scan all images in the given directory."""
     results = []
-    for img_path in sorted(Path(dir_path).glob("*.jpg")):
-        results.append(scan_image(img_path))
-    for img_path in sorted(Path(dir_path).glob("*.png")):
-        results.append(scan_image(img_path))
+    for ext in ("*.jpg", "*.png"):
+        for img_path in sorted(Path(dir_path).glob(ext)):
+            results.append(scan_image(img_path))
     return results
 
 
@@ -105,12 +118,26 @@ def scan_files(files: list[Path]) -> list:
     return results
 
 
+def aggregate_cards(data: list[dict]) -> list[dict]:
+    """Aggregate duplicate cards by name and number."""
+    aggregated: dict[tuple[str, str], dict] = defaultdict(
+        lambda: {"Name": "", "Number": "", "Ilość": 0}
+    )
+    for card in data:
+        key = (card.get("Name", ""), card.get("Number", ""))
+        aggregated[key]["Name"] = card.get("Name", "")
+        aggregated[key]["Number"] = card.get("Number", "")
+        aggregated[key]["Ilość"] += 1
+    return list(aggregated.values())
+
+
 def main():
     scans_dir = Path("assets/scans")
     output_path = Path("data/cards_scanned.csv")
-    data = scan_directory(scans_dir)
-    export_to_csv(data, str(output_path))
-    print(f"Saved {len(data)} records to {output_path}")
+    scanned_data = scan_directory(scans_dir)
+    grouped_data = aggregate_cards(scanned_data)
+    export_to_csv(grouped_data, str(output_path))
+    print(f"Zapisano {len(grouped_data)} rekordów do pliku {output_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refine OCR parsing to take name and set regions separately
- crop different areas of card image for name and number
- aggregate duplicate cards before exporting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_6863ab20bb00832fb9c4c561f79a3995