### PR TITLE
Improve card scanning and CSV export

### DIFF
--- a/scanner/data_exporter.py
+++ b/scanner/data_exporter.py
@@ -1,9 +1,30 @@
 """Utilities for exporting scanned data to CSV."""
 
-import pandas as pd
+from pathlib import Path
+import csv
 
 
 def export_to_csv(data, path: str) -> None:
-    """Save list of dictionaries to CSV."""
-    df = pd.DataFrame(data)
-    df.to_csv(path, index=False)
+    """Save list of dictionaries to a CSV file.
+
+    Parameters
+    ----------
+    data : list[dict]
+        The rows to write. Keys of the first dictionary define the CSV
+        header.
+    path : str
+        Destination file path.
+    """
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if not data:
+        target.write_text("")
+        return
+
+    fieldnames = list(data[0].keys())
+    with target.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(data)

--- a/tests/test_card_scanner.py
+++ b/tests/test_card_scanner.py
@@ -90,3 +90,16 @@ def test_scan_image_fallback(tmp_path, monkeypatch):
     assert not Path(calls[1][0]).exists()
     assert Path(calls[3][0]) != img_path
     assert not Path(calls[3][0]).exists()
+
+
+def test_export_to_csv(tmp_path):
+    rows = [
+        {"Name": "Test", "Number": "1/1", "Ilość": 2},
+        {"Name": "Foo", "Number": "2/2", "Ilość": 1},
+    ]
+    out_file = tmp_path / "out.csv"
+    card_scanner.export_to_csv(rows, str(out_file))
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert "Name" in content
+    assert "Test" in content


### PR DESCRIPTION
## Summary
- improve OCR routines for top name cropping
- robust card name filtering
- reimplement CSV export with `csv` module
- add test for export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ba0b47c8832f842853c8fcd3f1fe