### PR TITLE
Refactor OCR pipeline to accept PIL images

### DIFF
--- a/scanner/ocr_engine.py
+++ b/scanner/ocr_engine.py
@@ -1,5 +1,3 @@
-"""OCR and text analysis utilities."""
-
 import os
 import pytesseract
 from PIL import Image
@@ -10,20 +8,8 @@ if tesseract_cmd:
     pytesseract.pytesseract.tesseract_cmd = tesseract_cmd
 
 
-def extract_text(image_path: str, bbox=None) -> str:
-    """Return raw text from an image.
-
-    Parameters
-    ----------
-    image_path : str
-        Path to the source image.
-    bbox : tuple, optional
-        ``(left, upper, right, lower)`` bounding box. If provided, the image is
-        cropped to this area before OCR is performed.
-    """
-    image = Image.open(image_path)
-    if bbox:
-        image = image.crop(bbox)
+def extract_text(image: Image.Image) -> str:
+    """Return raw text from a PIL image."""
     try:
         return pytesseract.image_to_string(image, config="--psm 7")
     except pytesseract.pytesseract.TesseractNotFoundError as exc:


### PR DESCRIPTION
## Summary
- update `ocr_engine.extract_text` to accept a `PIL.Image` instance
- refactor `card_scanner.scan_image` to crop and enhance in-memory images
- remove legacy `_extract_text_compat` helper and unused imports
- adapt tests for the new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863bf78610c832fac6ebd8e73a2ea28