### PR TITLE
Fix runtime error in OCR engine

### DIFF
--- a/scanner/ocr_engine.py
+++ b/scanner/ocr_engine.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pytesseract
 from PIL import Image


### PR DESCRIPTION
## Summary
- import `annotations` from `__future__` in `ocr_engine.py` to defer evaluation of type hints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863d15e8de0832f87dcc6fc77520177