### PR TITLE
Add scan progress bar

### DIFF
--- a/gui_main_menu.py
+++ b/gui_main_menu.py
@@ -13,7 +13,22 @@ def start_scan():
     if not paths:
         return
 
-    data = card_scanner.scan_files([Path(p) for p in paths])
+    progress_win = tk.Toplevel()
+    progress_win.title("Postęp skanowania")
+    ttk.Label(progress_win, text="Skanowanie kart...").pack(padx=20, pady=(20, 10))
+    progress_var = tk.DoubleVar(value=0)
+    progress = ttk.Progressbar(progress_win, variable=progress_var, maximum=len(paths), length=300)
+    progress.pack(padx=20, pady=10)
+    status = ttk.Label(progress_win, text=f"0 / {len(paths)}")
+    status.pack(pady=(0, 20))
+
+    def update_progress(current: int, total: int) -> None:
+        progress_var.set(current)
+        status.config(text=f"{current} / {total}")
+        progress_win.update_idletasks()
+
+    data = card_scanner.scan_files([Path(p) for p in paths], progress_callback=update_progress)
+    progress_win.destroy()
     output = Path("data/cards_scanned.csv")
     card_scanner.export_to_csv(data, str(output))
     messagebox.showinfo(

--- a/scanner/card_scanner.py
+++ b/scanner/card_scanner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from collections import defaultdict
+from collections.abc import Callable
 import re
 import sys
 
@@ -294,11 +295,25 @@ def scan_directory(dir_path: Path) -> list:
     return results
 
 
-def scan_files(files: list[Path]) -> list:
-    """Scan a list of image paths."""
+def scan_files(
+    files: list[Path],
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> list:
+    """Scan a list of image paths.
+
+    Parameters
+    ----------
+    files : list[Path]
+        Images to process.
+    progress_callback : callable, optional
+        Function called with the current index and total after each file.
+    """
     results = []
-    for img_path in files:
+    total = len(files)
+    for idx, img_path in enumerate(files, 1):
         results.append(scan_image(img_path))
+        if progress_callback:
+            progress_callback(idx, total)
     return results
 
 


### PR DESCRIPTION
## Summary
- provide progress callback in `scan_files`
- show progress bar during scanning in the GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864cf4fd89c832fa1d8669de70b7a6d