### PR TITLE
Add API fallback by card number

### DIFF
--- a/tests/test_card_scanner.py
+++ b/tests/test_card_scanner.py
@@ -202,7 +202,7 @@ def test_lookup_with_number_and_set(tmp_path, monkeypatch):
 
     assert api_calls == [
         {"name": "Wrong Name", "number": "1/102", "set": None},
-        {"name": None, "number": "1/102", "set": "Base"},
+        {"name": None, "number": "1/102", "set": None},
     ]
     assert data["Name"] == "Pikachu"
     assert data["Set"] == "Base"


### PR DESCRIPTION
## Summary
- improve API query logging and results parsing
- retry API lookup using only card number
- update tests for new fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d067f698832f97c17cb3934de6d9