### PR TITLE
Add logo and animated scan cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The main menu lets you choose between scanning cards, viewing your collection, o
 Selecting **Skanowanie kart** opens a dialog where you can choose image files from disk. The scanned data
 is saved to `data/cards_scanned.csv`.
 
+The main window now displays the project logo at the top. During scanning an
+animation of sample cards plays above the progress bar providing visual
+feedback.
+
 ## Scanning cards from images
 
 Scans of cards placed in `assets/scans` can be processed in batch using


### PR DESCRIPTION
## Summary
- enhance main menu with logo and bigger window
- animate card images above scan progress bar
- note new GUI features in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d26643d8832fbd0069aea5e50736