### PR TITLE
Integrate ML predictions in scanning UI

### DIFF
--- a/gui_main_menu.py
+++ b/gui_main_menu.py
@@ -128,19 +128,47 @@ def show_scan_progress(paths: list[Path]) -> None:
 
     data = card_scanner.scan_files(paths, progress_callback=update_progress)
     running = False
-    save_path = filedialog.asksaveasfilename(
-        title="Zapisz dane skanowania",
-        initialdir="data",
-        defaultextension=".csv",
-        filetypes=[("CSV", "*.csv")],
-    )
-    if save_path:
-        card_scanner.export_to_csv(data, save_path)
-        messagebox.showinfo(
-            "Skanowanie zakonczone",
-            f"Zapisano {len(data)} rekordy do {save_path}"
-        )
+    show_scan_results(data)
     back_btn.config(state="normal")
+
+
+def show_scan_results(data: list[dict]) -> None:
+    """Display scanned card information and allow saving to CSV."""
+    if _content is None:
+        return
+
+    clear_content()
+    frame = ttk.Frame(_content)
+    frame.pack(fill="both", expand=True)
+
+    columns = ["CardID", "Name", "Number", "Set", "Type"]
+    tree = ttk.Treeview(frame, columns=columns, show="headings")
+    for col in columns:
+        tree.heading(col, text=col)
+        tree.column(col, width=120)
+    for row in data:
+        values = [row.get(c, "") for c in columns]
+        tree.insert("", "end", values=values)
+    tree.pack(fill="both", expand=True, pady=10)
+
+    def save() -> None:
+        save_path = filedialog.asksaveasfilename(
+            title="Zapisz dane skanowania",
+            initialdir="data",
+            defaultextension=".csv",
+            filetypes=[("CSV", "*.csv")],
+        )
+        if save_path:
+            card_scanner.export_to_csv(data, save_path)
+            messagebox.showinfo(
+                "Skanowanie zakonczone",
+                f"Zapisano {len(data)} rekordy do {save_path}"
+            )
+
+    btns = ttk.Frame(frame)
+    btns.pack(pady=10)
+    ttk.Button(btns, text="Zapisz do CSV", command=save).pack(side="left", padx=5)
+    ttk.Button(btns, text="Powrót", command=start_dashboard).pack(side="left", padx=5)
 
 
 def start_viewer() -> None:

--- a/scanner/card_scanner.py
+++ b/scanner/card_scanner.py
@@ -447,6 +447,7 @@ def scan_image(path: Path) -> dict:
     api_data = query_card_by_id(card_id)
 
     result = {
+        "CardID": card_id,
         "Name": "Unknown",
         "Number": "",
         "Set": "Unknown",

--- a/tests/test_card_scanner.py
+++ b/tests/test_card_scanner.py
@@ -60,6 +60,7 @@ def test_scan_image_with_api(tmp_path, monkeypatch):
     assert data["Set"] == "Base"
     assert data["Type"] == "holo"
     assert data["ImagePath"] == str(img)
+    assert data["CardID"] == "base-1/102"
 
 
 def test_scan_image_fallback(tmp_path, monkeypatch):
@@ -76,6 +77,7 @@ def test_scan_image_fallback(tmp_path, monkeypatch):
     assert data["Number"] == "2"
     assert data["Set"] == "base"
     assert data["Type"] == "common"
+    assert data["CardID"] == "base-2"
 
 
 def test_export_to_csv(tmp_path):


### PR DESCRIPTION
## Summary
- show `CardID` in scanning results
- add table of predictions in GUI and allow saving CSV
- test updates for new `CardID` field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651cee8a50832f82bb263c07d5ac8f