### PR TITLE
Add ML model helper modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Scanning cards also requires two PyTorch models located inside the
 
 - `card_model.pt` &ndash; predicts the card identifier
 - `type_model.pt` &ndash; detects whether the scan is a holo, reverse or
-  common card
+ common card
 
 Download the pretrained weights from the project's releases page and place the
 files directly in the `scanner/` folder. If downloads are unavailable you can
@@ -76,6 +76,9 @@ train the models yourself:
    `type_model.pt` from this dataset.
 3. Train `scanner.classifier.CardClassifier` with your own labeled images to
    generate `card_model.pt`.
+
+Helper functions for loading and training these networks are available in
+`scanner.card_model` and `scanner.type_model`.
 
 Without these files the scanning GUI will raise **"Card classifier model not
 found"** when it tries to load the models.

--- a/scanner/card_model.py
+++ b/scanner/card_model.py
@@ -1,0 +1,40 @@
+"""Utilities for loading and using the card identification model."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from PIL import Image
+
+try:
+    import torch
+    from torchvision import transforms
+except Exception:  # pragma: no cover - torch may be missing
+    torch = None
+    transforms = None
+
+from .classifier import CardClassifier
+
+MODEL_PATH = Path(__file__).resolve().parent / "card_model.pt"
+
+_model: CardClassifier | None = None
+
+
+def load(model_path: str | Path = MODEL_PATH) -> CardClassifier:
+    """Return a loaded :class:`CardClassifier` from ``model_path``."""
+    if not torch:
+        raise ImportError("PyTorch is required for prediction")
+    global _model
+    if _model is None:
+        if not Path(model_path).exists():
+            raise RuntimeError("Card classifier model not found")
+        _model = CardClassifier.load(model_path, device="cpu")
+    return _model
+
+
+def predict(image_path: str, model_path: str | Path = MODEL_PATH) -> str:
+    """Return predicted card identifier for ``image_path``."""
+    clf = load(model_path)
+    transform = transforms.Compose([transforms.Resize((64, 64)), transforms.ToTensor()])
+    img = Image.open(image_path).convert("RGB")
+    tensor = transform(img)
+    return clf.predict([tensor])[0]

--- a/scanner/type_model.py
+++ b/scanner/type_model.py
@@ -1,0 +1,82 @@
+"""Utilities for training and using the card type classifier."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import csv
+from PIL import Image
+
+try:
+    import torch
+    from torchvision import transforms
+except Exception:  # pragma: no cover - torch may be missing
+    torch = None
+    transforms = None
+
+from .classifier import CardClassifier
+
+DATASET_PATH = Path(__file__).resolve().parent / "dataset.csv"
+MODEL_PATH = Path(__file__).resolve().parent / "type_model.pt"
+
+_model: CardClassifier | None = None
+
+
+def _load_dataset(csv_path: str | Path) -> tuple[list[torch.Tensor], list[str]]:
+    """Return tensors and labels from ``csv_path``."""
+    if not torch:
+        raise ImportError("PyTorch is required for training")
+    images: list[torch.Tensor] = []
+    labels: list[str] = []
+
+    transform = transforms.Compose([transforms.Resize((64, 64)), transforms.ToTensor()])
+    with open(csv_path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            img = Image.open(row["image_path"]).convert("RGB")
+            images.append(transform(img))
+            label = "common"
+            if str(row.get("holo", "")).lower() in {"1", "true", "t"}:
+                label = "holo"
+            elif str(row.get("reverse", "")).lower() in {"1", "true", "t"}:
+                label = "reverse"
+            labels.append(label)
+    return images, labels
+
+
+def train_type_classifier(
+    csv_path: str | Path = DATASET_PATH,
+    model_path: str | Path = MODEL_PATH,
+    epochs: int = 1,
+) -> CardClassifier:
+    """Train the type classifier from labeled data and save to ``model_path``."""
+    if not torch:
+        raise ImportError("PyTorch is required for training")
+
+    images, labels = _load_dataset(csv_path)
+    clf = CardClassifier(num_classes=3, model_name="mobilenet", device="cpu")
+    clf.fit(images, labels, epochs=max(1, epochs))
+    clf.save(model_path)
+    global _model
+    _model = clf
+    return clf
+
+
+def _ensure_loaded(model_path: str | Path = MODEL_PATH) -> CardClassifier:
+    """Load the classifier if not already loaded."""
+    global _model
+    if _model is None:
+        if not Path(model_path).exists():
+            raise RuntimeError("Type classifier model not found")
+        _model = CardClassifier.load(model_path, device="cpu")
+    return _model
+
+
+def predict_type(image_path: str, model_path: str | Path = MODEL_PATH) -> str:
+    """Return predicted card type: ``holo``, ``reverse``, or ``common``."""
+    if not torch:
+        raise ImportError("PyTorch is required for prediction")
+    clf = _ensure_loaded(model_path)
+    transform = transforms.Compose([transforms.Resize((64, 64)), transforms.ToTensor()])
+    img = Image.open(image_path).convert("RGB")
+    tensor = transform(img)
+    return clf.predict([tensor])[0]


### PR DESCRIPTION
## Summary
- add `scanner.card_model` to encapsulate loading and predicting with `card_model.pt`
- add `scanner.type_model` for training and using `type_model.pt`
- document helper modules in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686521e59654832fabd4ac6e9b5e8393