### PR TITLE
Fix training editor crash with empty csv

### DIFF
--- a/scanner/training_editor_gui.py
+++ b/scanner/training_editor_gui.py
@@ -18,7 +18,10 @@ def append_images(csv_path: str | Path, image_paths: list[str]) -> pd.DataFrame:
     """Append ``image_paths`` as new rows to ``csv_path`` and return the DataFrame."""
     path = Path(csv_path)
     if path.exists():
-        df = pd.read_csv(path)
+        try:
+            df = pd.read_csv(path)
+        except pd.errors.EmptyDataError:
+            df = pd.DataFrame(columns=DEFAULT_COLUMNS)
     else:
         df = pd.DataFrame(columns=DEFAULT_COLUMNS)
     for p in image_paths:
@@ -31,7 +34,10 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
     """Launch the editor for ``csv_path``."""
     path = Path(csv_path)
     if path.exists():
-        df = pd.read_csv(path)
+        try:
+            df = pd.read_csv(path)
+        except pd.errors.EmptyDataError:
+            df = pd.DataFrame(columns=DEFAULT_COLUMNS)
     else:
         df = pd.DataFrame(columns=DEFAULT_COLUMNS)
 


### PR DESCRIPTION
## Summary
- handle empty CSV files when opening the training dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652ce6c980832f82d4cf35cd1ffe8d