### PR TITLE
Enhance training editor dataset handling

### DIFF
--- a/data/tcg_sets.json
+++ b/data/tcg_sets.json
@@ -1,1 +1,12 @@
-{"TWM": "Twilight Masquerade", "BRS": "Brilliant Stars"}
+{
+  "BRS": "Brilliant Stars",
+  "ASR": "Astral Radiance",
+  "LOR": "Lost Origin",
+  "SIT": "Silver Tempest",
+  "CRZ": "Crown Zenith",
+  "PAL": "Paldea Evolved",
+  "PAR": "Paradox Rift",
+  "TWM": "Twilight Masquerade",
+  "PRE": "Prismatic Evolution",
+  "SSP": "Shrouded Path"
+}

--- a/scanner/dataset_builder.py
+++ b/scanner/dataset_builder.py
@@ -26,10 +26,12 @@ def label_image(path: Path) -> Dict[str, object]:
 
     set_name = card_data.get("Set", "Unknown")
     number = card_data.get("Number", "")
+    name = card_data.get("Name", "Unknown")
     card_id = f"{set_name}-{number}" if set_name and number else ""
 
     return {
         "image_path": str(path),
+        "name": name,
         "card_id": card_id,
         "set": set_name,
         "holo": bool(image_data.get("holo")),
@@ -49,7 +51,8 @@ def build_dataset(scan_dir: str | Path, csv_path: str | Path | None = None) -> L
 
     with out.open("w", newline="", encoding="utf-8") as fh:
         writer = csv.DictWriter(
-            fh, fieldnames=["image_path", "card_id", "set", "holo", "reverse"]
+            fh,
+            fieldnames=["image_path", "name", "card_id", "set", "holo", "reverse"],
         )
         writer.writeheader()
         writer.writerows(rows)

--- a/scanner/training_editor_gui.py
+++ b/scanner/training_editor_gui.py
@@ -7,11 +7,12 @@ import tkinter as tk
 from tkinter import filedialog, ttk
 from PIL import Image, ImageTk
 import pandas as pd
+from .set_mapping import SET_MAP
 
 from . import dataset_builder
 
 DEFAULT_PATH = Path(__file__).resolve().parent / "dataset.csv"
-DEFAULT_COLUMNS = ["image_path", "card_id", "set", "holo", "reverse"]
+DEFAULT_COLUMNS = ["image_path", "name", "card_id", "set", "holo", "reverse"]
 
 
 def append_images(csv_path: str | Path, image_paths: list[str]) -> pd.DataFrame:
@@ -25,7 +26,7 @@ def append_images(csv_path: str | Path, image_paths: list[str]) -> pd.DataFrame:
     else:
         df = pd.DataFrame(columns=DEFAULT_COLUMNS)
     for p in image_paths:
-        df.loc[len(df)] = [p, "", "", False, False]
+        df.loc[len(df)] = [p, "", "", "", False, False]
     df.to_csv(path, index=False)
     return df
 
@@ -85,7 +86,17 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
             frm.pack(fill="x", padx=10, pady=2)
             ttk.Label(frm, text=col, width=12).pack(side="left")
             var = tk.StringVar(value=str(df.at[idx, col]))
-            ttk.Entry(frm, textvariable=var, width=30).pack(side="left", fill="x", expand=True)
+            if col == "set" and SET_MAP:
+                values = sorted(SET_MAP.keys())
+                ttk.Combobox(frm, textvariable=var, values=values, state="readonly").pack(
+                    side="left", fill="x", expand=True
+                )
+            elif col in {"holo", "reverse"}:
+                ttk.Combobox(frm, textvariable=var, values=["True", "False"], state="readonly").pack(
+                    side="left", fill="x", expand=True
+                )
+            else:
+                ttk.Entry(frm, textvariable=var, width=30).pack(side="left", fill="x", expand=True)
             vars[col] = var
 
         def close() -> None:
@@ -111,7 +122,7 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
         if not paths:
             return
         for p in paths:
-            df.loc[len(df)] = [p, "", "", False, False]
+            df.loc[len(df)] = [p, "", "", "", False, False]
             tree.insert("", "end", iid=str(len(df) - 1), values=list(df.loc[len(df) - 1]))
         save_df()
 

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -4,10 +4,11 @@ def test_label_image(tmp_path, monkeypatch):
     img = tmp_path / 'img.jpg'
     img.write_text('')
 
-    monkeypatch.setattr(db, 'scan_image', lambda p: {'Set': 'Base', 'Number': '1/102'})
+    monkeypatch.setattr(db, 'scan_image', lambda p: {'Name': 'Test', 'Set': 'Base', 'Number': '1/102'})
     monkeypatch.setattr(db, 'analyze_image', lambda p: {'holo': True, 'reverse': False})
 
     row = db.label_image(img)
+    assert row['name'] == 'Test'
     assert row['card_id'] == 'Base-1/102'
     assert row['holo'] is True
     assert row['reverse'] is False
@@ -18,7 +19,7 @@ def test_build_dataset(tmp_path, monkeypatch):
     img1.write_text('')
     img2.write_text('')
 
-    monkeypatch.setattr(db, 'scan_image', lambda p: {'Set': 'Set', 'Number': '2'})
+    monkeypatch.setattr(db, 'scan_image', lambda p: {'Name': 'X', 'Set': 'Set', 'Number': '2'})
     monkeypatch.setattr(db, 'analyze_image', lambda p: {'holo': False, 'reverse': True})
 
     out_csv = tmp_path / 'out.csv'
@@ -26,4 +27,4 @@ def test_build_dataset(tmp_path, monkeypatch):
     assert len(rows) == 2
     assert out_csv.exists()
     text = out_csv.read_text()
-    assert 'image_path,card_id,set,holo,reverse' in text
+    assert 'image_path,name,card_id,set,holo,reverse' in text


### PR DESCRIPTION
## Summary
- expand `tcg_sets.json` with more sets and short names
- include card `name` in dataset creation
- improve training data editor with name column and dropdown fields
- adjust dataset builder tests for new format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658b740460832f95d40ba75924c2ed