### PR TITLE
Add scaling, pagination and style tweaks

### DIFF
--- a/dashboard/dashboard_gui.py
+++ b/dashboard/dashboard_gui.py
@@ -87,8 +87,9 @@ class DashboardFrame(ttk.Frame):
 
     # --- Charts ------------------------------------------------------------
     def create_charts(self) -> None:
-        line_fig = Figure(figsize=(4, 3), dpi=100)
-        ax = line_fig.add_subplot(111)
+        bg = self.cget("background")
+        line_fig = Figure(figsize=(4, 3), dpi=100, facecolor=bg)
+        ax = line_fig.add_subplot(111, facecolor=bg)
         if "Date" in self.df.columns:
             counts = self.df.groupby("Date").size().sort_index()
             ax.plot(counts.index, counts.values, marker="o")
@@ -99,18 +100,20 @@ class DashboardFrame(ttk.Frame):
         ax.set_title("Liczba kart vs czas")
         ax.set_xlabel("Dzień")
         ax.set_ylabel("Ilość")
+        line_fig.tight_layout()
         canvas = FigureCanvasTkAgg(line_fig, master=self._charts_frame)
         canvas.draw()
         canvas.get_tk_widget().pack(side="left", fill="both", expand=True)
 
-        pie_fig = Figure(figsize=(4, 3), dpi=100)
-        ax2 = pie_fig.add_subplot(111)
+        pie_fig = Figure(figsize=(4, 3), dpi=100, facecolor=bg)
+        ax2 = pie_fig.add_subplot(111, facecolor=bg)
         if "Rarity" in self.df.columns and not self.df.empty:
             counts = self.df["Rarity"].value_counts()
             ax2.pie(counts.values, labels=counts.index, autopct="%1.0f%%")
         else:
             ax2.pie([1], labels=["Brak danych"])
         ax2.set_title("Typy kart")
+        pie_fig.tight_layout()
         canvas2 = FigureCanvasTkAgg(pie_fig, master=self._charts_frame)
         canvas2.draw()
         canvas2.get_tk_widget().pack(side="left", fill="both", expand=True)

--- a/gui_main_menu.py
+++ b/gui_main_menu.py
@@ -5,6 +5,8 @@ from PIL import Image, ImageTk
 from scanner import card_scanner
 import sv_ttk
 
+_scale: float = 1.0
+
 _root: tk.Tk | None = None
 _sidebar: ttk.Frame | None = None
 _content: ttk.Frame | None = None
@@ -189,7 +191,7 @@ def start_viewer() -> None:
         return
     frame = ttk.Frame(_content)
     frame.pack(fill="both", expand=True)
-    viewer_gui.run(str(csv_path), master=frame)
+    viewer_gui.run(str(csv_path), master=frame, page_size=50)
     ttk.Button(frame, text="Powrót", command=start_dashboard).pack(pady=10)
 
 
@@ -230,7 +232,7 @@ def start_sales():
 
 
 def main():
-    global _root, _sidebar, _content
+    global _root, _sidebar, _content, _scale
     root = tk.Tk()
     _root = root
     root.title("TCG Organizer")
@@ -239,6 +241,7 @@ def main():
         root.iconphoto(False, tk.PhotoImage(file=icon_path))
     root.geometry("900x600")
     root.resizable(True, True)
+    root.tk.call("tk", "scaling", _scale)
 
     # Styl "Sun Valley" (sv-ttk) przypominający Windows 11
     style = ttk.Style(root)
@@ -265,6 +268,29 @@ def main():
 
     _content = ttk.Frame(body)
     _content.pack(side="left", fill="both", expand=True, padx=10, pady=10)
+
+    scale_frame = ttk.Frame(root)
+    scale_frame.pack(side="bottom", pady=(0, 5))
+    ttk.Label(scale_frame, text="Skalowanie:").pack(side="left", padx=(0, 5))
+    scale_var = tk.StringVar(value=str(_scale))
+
+    def _on_scale(event: tk.Event | None = None) -> None:
+        global _scale
+        try:
+            _scale = float(scale_var.get())
+        except Exception:
+            return
+        root.tk.call("tk", "scaling", _scale)
+
+    cmb = ttk.Combobox(
+        scale_frame,
+        textvariable=scale_var,
+        values=["0.8", "1.0", "1.2", "1.5"],
+        width=5,
+        state="readonly",
+    )
+    cmb.bind("<<ComboboxSelected>>", _on_scale)
+    cmb.pack(side="left")
 
     ttk.Label(root, text="power by boguckicollection", font=("Segoe UI", 8)).pack(side="bottom", pady=10)
 

--- a/scanner/training_editor_gui.py
+++ b/scanner/training_editor_gui.py
@@ -88,15 +88,23 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
             var = tk.StringVar(value=str(df.at[idx, col]))
             if col == "set" and SET_MAP:
                 values = sorted(SET_MAP.keys())
-                ttk.Combobox(frm, textvariable=var, values=values, state="readonly").pack(
-                    side="left", fill="x", expand=True
-                )
+                ttk.Combobox(
+                    frm,
+                    textvariable=var,
+                    values=values,
+                    state="readonly",
+                    width=30,
+                ).pack(side="left")
             elif col in {"holo", "reverse"}:
-                ttk.Combobox(frm, textvariable=var, values=["True", "False"], state="readonly").pack(
-                    side="left", fill="x", expand=True
-                )
+                ttk.Combobox(
+                    frm,
+                    textvariable=var,
+                    values=["True", "False"],
+                    state="readonly",
+                    width=30,
+                ).pack(side="left")
             else:
-                ttk.Entry(frm, textvariable=var, width=30).pack(side="left", fill="x", expand=True)
+                ttk.Entry(frm, textvariable=var, width=30).pack(side="left")
             vars[col] = var
 
         def close() -> None:


### PR DESCRIPTION
## Summary
- add scaling selection combo to main window
- paginate items in the collection viewer
- fix constant size editing fields in training editor
- style dashboard charts to match theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686595a82cb4832f80e56c022b30c6c6