### PR TITLE
Improve GUI consistency

### DIFF
--- a/dashboard/dashboard_gui.py
+++ b/dashboard/dashboard_gui.py
@@ -10,6 +10,7 @@ from tkinter import ttk
 import pandas as pd
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.figure import Figure
+from gui_utils import init_tk_theme, TITLE_FONT
 
 DATA_FILE = Path("data/main.csv")
 
@@ -27,7 +28,7 @@ class DashboardFrame(ttk.Frame):
             ttk.Label(
                 self._sidebar,
                 text="SmartScan TCG",
-                font=("Poppins", 16, "bold"),
+                font=TITLE_FONT,
                 padding=10,
             ).pack()
             for name in [
@@ -80,7 +81,7 @@ class DashboardFrame(ttk.Frame):
         ):
             frame = ttk.Frame(self._stats_frame, padding=10, relief="ridge")
             frame.grid(row=0, column=i, padx=5, pady=5, sticky="nsew")
-            ttk.Label(frame, text=str(value), font=("Poppins", 16, "bold")).pack()
+            ttk.Label(frame, text=str(value), font=TITLE_FONT).pack()
             ttk.Label(frame, text=label).pack()
         for i in range(4):
             self._stats_frame.columnconfigure(i, weight=1)
@@ -148,7 +149,7 @@ class Dashboard(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
         self.title("SmartScan Dashboard")
-        self.geometry("900x600")
+        init_tk_theme(self)
         self.configure(bg="#f4f4f7")
 
         DashboardFrame(self, show_sidebar=True).pack(fill="both", expand=True)

--- a/gui_main_menu.py
+++ b/gui_main_menu.py
@@ -3,7 +3,12 @@ import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 from PIL import Image, ImageTk
 from scanner import card_scanner
-import sv_ttk
+from gui_utils import (
+    init_tk_theme,
+    set_window_icon,
+    TITLE_FONT,
+    FOOTER_FONT,
+)
 
 _scale: float = 1.0
 
@@ -170,7 +175,7 @@ def show_scan_results(data: list[dict]) -> None:
             card_scanner.export_to_csv(data, save_path)
             messagebox.showinfo(
                 "Skanowanie zakonczone",
-                f"Zapisano {len(data)} rekordy do {save_path}"
+                f"Zapisano {len(data)} rekordów do {save_path}"
             )
 
     btns = ttk.Frame(frame)
@@ -237,15 +242,9 @@ def main():
     _root = root
     root.title("TCG Organizer")
     icon_path = Path(__file__).resolve().parent / "assets" / "logo.png"
-    if icon_path.exists():
-        root.iconphoto(False, tk.PhotoImage(file=icon_path))
-    root.geometry("900x600")
-    root.resizable(True, True)
+    set_window_icon(root, str(icon_path) if icon_path.exists() else None)
     root.tk.call("tk", "scaling", _scale)
-
-    # Styl "Sun Valley" (sv-ttk) przypominający Windows 11
-    style = ttk.Style(root)
-    sv_ttk.set_theme("dark")
+    init_tk_theme(root)
 
     logo_path = Path(__file__).resolve().parent / "assets" / "logo.png"
     if logo_path.exists():
@@ -255,10 +254,10 @@ def main():
         header = ttk.Frame(root)
         header.pack(pady=(20, 10))
         ttk.Label(header, image=logo_img).pack(side="left", padx=(0, 10))
-        ttk.Label(header, text="TCG Organizer", font=("Segoe UI", 18, "bold")).pack(side="left")
+        ttk.Label(header, text="TCG Organizer", font=TITLE_FONT).pack(side="left")
         root.logo_img = logo_img
     else:
-        ttk.Label(root, text="TCG Organizer", font=("Segoe UI", 18, "bold")).pack(pady=(20, 10))
+        ttk.Label(root, text="TCG Organizer", font=TITLE_FONT).pack(pady=(20, 10))
 
     body = ttk.Frame(root)
     body.pack(fill="both", expand=True)
@@ -292,7 +291,7 @@ def main():
     cmb.bind("<<ComboboxSelected>>", _on_scale)
     cmb.pack(side="left")
 
-    ttk.Label(root, text="power by boguckicollection", font=("Segoe UI", 8)).pack(side="bottom", pady=10)
+    ttk.Label(root, text="power by boguckicollection", font=FOOTER_FONT).pack(side="bottom", pady=10)
 
     build_sidebar()
     start_dashboard()

--- a/gui_utils.py
+++ b/gui_utils.py
@@ -1,0 +1,31 @@
+"""Common helpers for initializing Tkinter GUIs."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+
+import sv_ttk
+
+
+TITLE_FONT = ("Segoe UI", 18, "bold")
+FOOTER_FONT = ("Segoe UI", 8)
+
+def init_tk_theme(win: tk.Tk) -> None:
+    """Apply common window settings and sv-ttk theme."""
+    win.geometry("900x600")
+    win.resizable(True, True)
+    sv_ttk.set_theme("dark")
+    style = ttk.Style(win)
+    style.configure("TLabel", font=("Segoe UI", 10))
+
+
+
+def set_window_icon(win: tk.Tk, icon_path: str | None = None) -> None:
+    """Set window icon if the file exists."""
+    if icon_path:
+        try:
+            win.iconphoto(False, tk.PhotoImage(file=icon_path))
+        except Exception:
+            pass
+

--- a/scanner/scanner_gui.py
+++ b/scanner/scanner_gui.py
@@ -2,10 +2,12 @@
 
 import tkinter as tk
 from tkinter import ttk
+from gui_utils import init_tk_theme
 
 
 def run():
     root = tk.Tk()
     root.title("Card Scanner")
+    init_tk_theme(root)
     ttk.Label(root, text="Scanner placeholder").pack(padx=20, pady=20)
     root.mainloop()

--- a/scanner/training_editor_gui.py
+++ b/scanner/training_editor_gui.py
@@ -8,6 +8,7 @@ from tkinter import filedialog, ttk
 from PIL import Image, ImageTk
 import pandas as pd
 from .set_mapping import SET_MAP
+from gui_utils import init_tk_theme
 
 from . import dataset_builder
 
@@ -46,6 +47,7 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
         win = tk.Tk()
         container: tk.Widget = win
         win.title("Training Data Editor")
+        init_tk_theme(win)
     else:
         container = ttk.Frame(master)
         container.pack(fill="both", expand=True)

--- a/viewer/viewer_gui.py
+++ b/viewer/viewer_gui.py
@@ -7,6 +7,7 @@ import tkinter as tk
 from tkinter import ttk
 from PIL import Image, ImageTk
 import pandas as pd
+from gui_utils import init_tk_theme
 
 from scanner.set_mapping import SET_MAP
 
@@ -44,6 +45,7 @@ def run(
         win = tk.Tk()
         container: tk.Widget = win
         win.title("Collection Viewer")
+        init_tk_theme(win)
     else:
         container = ttk.Frame(master)
         container.pack(fill="both", expand=True)


### PR DESCRIPTION
## Summary
- apply a common sv-ttk theme across all GUI modules
- add helper `gui_utils` to centralize theme logic
- update fonts and fix minor message typo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659c5c19d8832fb7f8e13ec10e7570