### PR TITLE
Enhance theme and training editor

### DIFF
--- a/gui_utils.py
+++ b/gui_utils.py
@@ -19,11 +19,9 @@ def init_tk_theme(win: tk.Misc) -> None:
     if isinstance(win, ctk.CTk):
         ctk.set_appearance_mode("dark")
         ctk.set_default_color_theme("dark-blue")
-        style = ttk.Style()
-    else:
-        sv_ttk.set_theme("dark")
-        style = ttk.Style(win)
-    style.configure("TLabel", font=("Arial", 10))
+    sv_ttk.set_theme("dark")
+    style = ttk.Style(win)
+    style.configure("TLabel", font=("Arial", 10), foreground="white")
 
 
 

--- a/sales/sales_gui.py
+++ b/sales/sales_gui.py
@@ -4,9 +4,12 @@ import tkinter as tk
 from tkinter import ttk
 import customtkinter as ctk
 
+from gui_utils import init_tk_theme
+
 
 def run():
     root = ctk.CTk()
     root.title("Sales Analyzer")
+    init_tk_theme(root)
     ttk.Label(root, text="Sales analyzer placeholder").pack(padx=20, pady=20)
     root.mainloop()

--- a/scanner/training_editor_gui.py
+++ b/scanner/training_editor_gui.py
@@ -9,6 +9,9 @@ import customtkinter as ctk
 from PIL import Image, ImageTk
 import pandas as pd
 from .set_mapping import SET_MAP
+
+# Reverse lookup of set names to their abbreviations
+INV_SET_MAP: dict[str, str] = {v: k for k, v in SET_MAP.items()}
 from gui_utils import init_tk_theme
 
 from . import dataset_builder, image_analyzer
@@ -117,9 +120,11 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
             frm = ctk.CTkFrame(detail, fg_color="transparent")
             frm.pack(fill="x", padx=10, pady=2)
             ctk.CTkLabel(frm, text=col, width=120).pack(side="left")
-            var = tk.StringVar(value=str(df.at[idx, col]))
+            value = str(df.at[idx, col])
             if col == "set" and SET_MAP:
-                values = sorted(SET_MAP.keys())
+                display = SET_MAP.get(value.upper(), value)
+                var = tk.StringVar(value=display)
+                values = sorted(SET_MAP.values())
                 ttk.Combobox(
                     frm,
                     textvariable=var,
@@ -128,6 +133,7 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
                     width=30,
                 ).pack(side="left")
             elif col in {"holo", "reverse"}:
+                var = tk.StringVar(value=value)
                 ttk.Combobox(
                     frm,
                     textvariable=var,
@@ -136,6 +142,7 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
                     width=30,
                 ).pack(side="left")
             else:
+                var = tk.StringVar(value=value)
                 ttk.Entry(frm, textvariable=var, width=30).pack(side="left")
             vars[col] = var
 
@@ -145,7 +152,10 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
 
         def save() -> None:
             for col, var in vars.items():
-                df.at[idx, col] = var.get()
+                val = var.get()
+                if col == "set" and SET_MAP:
+                    val = INV_SET_MAP.get(val, val)
+                df.at[idx, col] = val
             save_df()
             tree.item(item, values=list(df.loc[idx]))
             close()


### PR DESCRIPTION
## Summary
- unify Tk theme initialization across all windows
- apply dark theme to sales GUI as well
- display full TCG set names in the training editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686624fd0c1c832fa06d4ab1e71df238