### PR TITLE
Improve manual card editing and ID generation

### DIFF
--- a/scanner/dataset_builder.py
+++ b/scanner/dataset_builder.py
@@ -36,6 +36,9 @@ def label_image(path: Path) -> Dict[str, object]:
         "set": set_name,
         "holo": bool(image_data.get("holo")),
         "reverse": bool(image_data.get("reverse")),
+        "karton": "",
+        "rzad": "",
+        "pozycja": "",
     }
 
 
@@ -52,7 +55,17 @@ def build_dataset(scan_dir: str | Path, csv_path: str | Path | None = None) -> L
     with out.open("w", newline="", encoding="utf-8") as fh:
         writer = csv.DictWriter(
             fh,
-            fieldnames=["image_path", "name", "card_id", "set", "holo", "reverse"],
+            fieldnames=[
+                "image_path",
+                "name",
+                "card_id",
+                "set",
+                "holo",
+                "reverse",
+                "karton",
+                "rzad",
+                "pozycja",
+            ],
         )
         writer.writeheader()
         writer.writerows(rows)


### PR DESCRIPTION
## Summary
- extend dataset format with `karton`, `rzad` and `pozycja`
- add filterable combobox for choosing card set in the training editor
- auto-create card ID as `K{karton}_R{rzad}_P{pozycja}` when saving

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866323e429c832f861b17ef507f5a0c