### PR TITLE
Fix dataset column mismatch handling

### DIFF
--- a/scanner/training_editor_gui.py
+++ b/scanner/training_editor_gui.py
@@ -55,6 +55,10 @@ def append_images(csv_path: str | Path, image_paths: list[str]) -> pd.DataFrame:
             df = pd.DataFrame(columns=DEFAULT_COLUMNS)
     else:
         df = pd.DataFrame(columns=DEFAULT_COLUMNS)
+
+    if list(df.columns) != DEFAULT_COLUMNS:
+        df = df.reindex(columns=DEFAULT_COLUMNS, fill_value="")
+
     for p in image_paths:
         df.loc[len(df)] = [p, "", "", "", False, False, "", "", ""]
     df.to_csv(path, index=False)
@@ -206,6 +210,12 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
         paths = filedialog.askopenfilenames(title="Wybierz obrazy", filetypes=[("Image files", "*.jpg *.png")])
         if not paths:
             return
+        if list(df.columns) != DEFAULT_COLUMNS:
+            messagebox.showerror(
+                "Błędne kolumny",
+                "CSV ma niezgodne kolumny i nie można dodać wierszy.",
+            )
+            return
         for p in paths:
             df.loc[len(df)] = [p, "", "", "", False, False, "", "", ""]
             tree.insert("", "end", iid=str(len(df) - 1), values=list(df.loc[len(df) - 1]))
@@ -217,6 +227,12 @@ def run(csv_path: str | Path = DEFAULT_PATH, master: tk.Misc | None = None) -> t
             filetypes=[("Image files", "*.jpg *.png")],
         )
         if not paths:
+            return
+        if list(df.columns) != DEFAULT_COLUMNS:
+            messagebox.showerror(
+                "Błędne kolumny",
+                "CSV ma niezgodne kolumny i nie można dodać wierszy.",
+            )
             return
         for p in paths:
             try:

--- a/tests/test_training_editor_gui.py
+++ b/tests/test_training_editor_gui.py
@@ -11,3 +11,13 @@ def test_append_images(tmp_path):
     assert csv.exists()
     saved = pd.read_csv(csv)
     assert list(saved["image_path"]) == ["a.jpg", "b.jpg"]
+
+
+def test_append_images_reindex(tmp_path):
+    csv = tmp_path / "bad.csv"
+    pd.DataFrame({"x": []}).to_csv(csv, index=False)
+    df = teg.append_images(csv, ["c.jpg"])
+    assert list(df.columns) == teg.DEFAULT_COLUMNS
+    saved = pd.read_csv(csv)
+    assert list(saved.columns) == teg.DEFAULT_COLUMNS
+    assert saved.loc[0, "image_path"] == "c.jpg"


### PR DESCRIPTION
## Summary
- align columns when appending images to training CSVs
- guard GUI add/scan buttons when dataset columns don't match
- test for column reindexing in `append_images`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866412f9d30832f8247f1ba5ed232d7