### PR TITLE
Improve dataset generator error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ train the models yourself:
 3. Train `scanner.classifier.CardClassifier` with your own labeled images to
    generate `card_model.pt`.
 
+The repository's `scanner/dataset.csv` is intentionally empty. Run the dataset
+builder first to fill it before using scripts like `generate_type_dataset.py`.
+
 Using a CSV with different columns will cause errors in the training editor.
 To append images while maintaining this layout, call
 `training_editor_gui.append_images`.

--- a/generate_type_dataset.py
+++ b/generate_type_dataset.py
@@ -28,7 +28,13 @@ def main() -> None:
     type_output_base = Path(args.type_dir)
     card_output_base = Path(args.card_dir)
 
-    df = pd.read_csv(csv_path)
+    try:
+        df = pd.read_csv(csv_path)
+    except pd.errors.EmptyDataError as exc:
+        raise SystemExit(
+            "Dataset CSV is empty. Run 'scanner.dataset_builder.build_dataset' "
+            "on your labeled card scans to populate it."
+        ) from exc
 
     def determine_type(row):
         holo = str(row.get("holo", "")).strip().lower() == "true"


### PR DESCRIPTION
## Summary
- raise a clear SystemExit if `dataset.csv` is empty when generating type dataset
- clarify that `scanner/dataset.csv` is an empty placeholder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686789977114832f9f3aacfa609e9b02