### PR TITLE
Add GUI for manual card entry

### DIFF
--- a/gui_main_menu.py
+++ b/gui_main_menu.py
@@ -51,6 +51,7 @@ def build_sidebar() -> None:
 
     add_btn("📊 Dashboard", start_dashboard)
     add_btn("📚 Przeglądanie kolekcji", start_viewer)
+    add_btn("➕ Dodaj kartę", start_add_card)
     add_btn("🔗 Scal CSV", merge_csv_dialog)
     add_btn("💰 Analiza sprzedaży", start_sales)
 
@@ -194,6 +195,12 @@ def start_viewer() -> None:
     frame.pack(fill="both", expand=True)
     viewer_gui.run(str(csv_path), master=frame, page_size=50)
     ctk.CTkButton(frame, text="Powrót", command=start_dashboard).pack(pady=10)
+
+
+def start_add_card() -> None:
+    """Open the add card dialog window."""
+    import viewer.add_card_gui as add_gui
+    add_gui.run(_root, csv_path=Path("data/main.csv"))
 
 
 def start_training_editor() -> None:

--- a/tests/test_add_card_gui.py
+++ b/tests/test_add_card_gui.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from viewer.add_card_gui import save_card
+
+
+def test_save_card_appends_row(tmp_path):
+    csv = tmp_path / "main.csv"
+    csv.write_text("Name,Set,Rarity,Number,Quantity,ImagePath\n")
+    row = {
+        "Name": "Pikachu",
+        "Set": "Base",
+        "Number": "1/102",
+        "Rarity": "Common",
+        "Quantity": "2",
+        "ImagePath": "img.jpg",
+    }
+    save_card(row, csv)
+    df = pd.read_csv(csv)
+    assert len(df) == 1
+    assert df.loc[0, "Name"] == "Pikachu"
+    assert df.loc[0, "Quantity"] == "2"

--- a/viewer/add_card_gui.py
+++ b/viewer/add_card_gui.py
@@ -1,0 +1,88 @@
+"""Simple form for manually adding a card entry to ``data/main.csv``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tkinter as tk
+from tkinter import ttk, filedialog
+import customtkinter as ctk
+
+from gui_utils import init_tk_theme
+from scanner import card_scanner
+from . import collection_utils
+
+
+DEFAULT_CSV = Path("data/main.csv")
+
+
+def save_card(data: dict[str, str], csv_path: str | Path = DEFAULT_CSV) -> None:
+    """Append ``data`` as a row to ``csv_path`` using ``collection_utils``."""
+    collection_utils.append_row(csv_path, data)
+
+
+def run(master: tk.Misc | None = None, csv_path: str | Path = DEFAULT_CSV) -> tk.Widget | None:
+    """Launch the Add Card window."""
+    if master is None:
+        win = ctk.CTk()
+        container: tk.Misc = win
+        win.title("Dodaj kartę")
+        init_tk_theme(win)
+    else:
+        win = ctk.CTkToplevel(master)
+        container = win
+        win.title("Dodaj kartę")
+
+    vars: dict[str, tk.StringVar] = {}
+    fields = ["Name", "Set", "Number", "Rarity", "Quantity", "ImagePath"]
+    for field in fields:
+        vars[field] = tk.StringVar()
+
+    frm = ctk.CTkFrame(container, fg_color="transparent")
+    frm.pack(padx=10, pady=10)
+
+    for field in fields:
+        row = ctk.CTkFrame(frm, fg_color="transparent")
+        row.pack(fill="x", pady=2)
+        ttk.Label(row, text=field, width=10).pack(side="left")
+        entry = ttk.Entry(row, textvariable=vars[field], width=40)
+        entry.pack(side="left", fill="x", expand=True)
+        if field == "ImagePath":
+            def browse(f=field):
+                path = filedialog.askopenfilename(
+                    title="Wybierz obraz", filetypes=[("Image files", "*.jpg *.png")]
+                )
+                if path:
+                    vars[f].set(path)
+            ttk.Button(row, text="...", width=3, command=browse).pack(side="left")
+
+    btns = ctk.CTkFrame(frm, fg_color="transparent")
+    btns.pack(pady=5)
+
+    def from_image() -> None:
+        path = filedialog.askopenfilename(
+            title="Wybierz obraz", filetypes=[("Image files", "*.jpg *.png")]
+        )
+        if not path:
+            return
+        data = card_scanner.scan_image(Path(path))
+        vars["Name"].set(data.get("Name", ""))
+        vars["Set"].set(data.get("Set", ""))
+        vars["Number"].set(data.get("Number", ""))
+        vars["Rarity"].set(data.get("Rarity", ""))
+        vars["ImagePath"].set(path)
+        vars["Quantity"].set("1")
+
+    def save() -> None:
+        row = {k: v.get() for k, v in vars.items()}
+        save_card(row, csv_path)
+        for v in vars.values():
+            v.set("")
+
+    ctk.CTkButton(btns, text="Dodaj z obrazu", command=from_image).pack(side="left", padx=5)
+    ctk.CTkButton(btns, text="Zapisz", command=save).pack(side="left", padx=5)
+
+    if master is None:
+        container.mainloop()
+        return None
+    return container
+

--- a/viewer/collection_utils.py
+++ b/viewer/collection_utils.py
@@ -29,3 +29,25 @@ def merge_csv_files(paths: list[str], output: str) -> pd.DataFrame:
 def missing_cards(df: pd.DataFrame, set_name: str) -> pd.DataFrame:
     """Return rows for missing cards from a given set."""
     return df[df["Set"] == set_name]
+
+
+def append_row(csv_path: str | Path, row: dict) -> pd.DataFrame:
+    """Append ``row`` as a new entry to ``csv_path`` and return the DataFrame."""
+    path = Path(csv_path)
+    if path.exists():
+        try:
+            df = pd.read_csv(path)
+        except pd.errors.EmptyDataError:
+            df = pd.DataFrame()
+    else:
+        df = pd.DataFrame()
+
+    columns = list(df.columns)
+    for key in row:
+        if key not in columns:
+            columns.append(key)
+    df = df.reindex(columns=columns, fill_value="")
+    df.loc[len(df)] = [row.get(c, "") for c in df.columns]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+    return df


### PR DESCRIPTION
## Summary
- implement viewer/add_card_gui for quick single card entry
- allow appending card rows to collection via collection_utils.append_row
- expose add card function in GUI sidebar
- test helper that saving a card appends to csv

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas' and 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b78bbb3cc832f8474a6b4dd55c5fa